### PR TITLE
Add local data manager tests

### DIFF
--- a/The Movie DB Client.xcodeproj/project.pbxproj
+++ b/The Movie DB Client.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		65B32D6620AE7055007F55B4 /* TMDbApiConfiguration+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B32D6520AE7055007F55B4 /* TMDbApiConfiguration+CoreDataProperties.swift */; };
 		65B32D6820AE70D9007F55B4 /* TMDbApiConfigurationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B32D6720AE70D9007F55B4 /* TMDbApiConfigurationResponse.swift */; };
 		65D0F5EF20C102F500B45F2D /* Hippolyte.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 651B2B5720C0FC99008DF785 /* Hippolyte.framework */; };
+		65D8E10D21447D4F001A73FB /* Factories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D8E10C21447D4F001A73FB /* Factories.swift */; };
 		65F0099220A9161600F4E363 /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F0099120A9161600F4E363 /* Secrets.swift */; };
 		65F0099420A9191C00F4E363 /* Secrets.swift.example in Sources */ = {isa = PBXBuildFile; fileRef = 65F0099320A9191C00F4E363 /* Secrets.swift.example */; };
 		65F0099720A9206200F4E363 /* MovieListPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F0099620A9206200F4E363 /* MovieListPresenter.swift */; };
@@ -183,6 +184,7 @@
 		65B32D6320AE703B007F55B4 /* TMDbApiConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TMDbApiConfiguration.swift; sourceTree = "<group>"; };
 		65B32D6520AE7055007F55B4 /* TMDbApiConfiguration+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TMDbApiConfiguration+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		65B32D6720AE70D9007F55B4 /* TMDbApiConfigurationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TMDbApiConfigurationResponse.swift; sourceTree = "<group>"; };
+		65D8E10C21447D4F001A73FB /* Factories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Factories.swift; sourceTree = "<group>"; };
 		65F0099120A9161600F4E363 /* Secrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
 		65F0099320A9191C00F4E363 /* Secrets.swift.example */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Secrets.swift.example; sourceTree = "<group>"; };
 		65F0099620A9206200F4E363 /* MovieListPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieListPresenter.swift; sourceTree = "<group>"; };
@@ -377,6 +379,7 @@
 				6557FE57209B52A6004DEC8D /* Info.plist */,
 				65F009AA20A92EAC00F4E363 /* movie_sample_data.json */,
 				2E81458C211E582700F3E0A2 /* TestHelpers.swift */,
+				65D8E10C21447D4F001A73FB /* Factories.swift */,
 			);
 			path = "The Movie DB ClientTests";
 			sourceTree = "<group>";
@@ -816,6 +819,7 @@
 				6588D79120BF978C0090BB6F /* JsonHelper.swift in Sources */,
 				2EE3AAC520B27C2400C4CD6A /* MovieListMocks.swift in Sources */,
 				2E02A23120B4DD1F008B93F5 /* MovieDetailMocks.swift in Sources */,
+				65D8E10D21447D4F001A73FB /* Factories.swift in Sources */,
 				2E81458D211E582700F3E0A2 /* TestHelpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/The Movie DB Client.xcodeproj/project.pbxproj
+++ b/The Movie DB Client.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		2E02A23720B4DF9B008B93F5 /* PKHUD.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65B32D5F20AE6A8B007F55B4 /* PKHUD.framework */; };
 		2E02A23820B4DF9B008B93F5 /* SwiftMessages.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2E14CFBF20B0BDA2000E1724 /* SwiftMessages.framework */; };
 		2E14CFC220B0BDE4000E1724 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = 2E14CFC120B0BDE4000E1724 /* Makefile */; };
+		2E81458D211E582700F3E0A2 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E81458C211E582700F3E0A2 /* TestHelpers.swift */; };
 		2EC1335E20B4F4A2004ABAD1 /* Mock+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EC1335D20B4F4A2004ABAD1 /* Mock+Extensions.swift */; };
 		2ECCE95820B0CCB400FE338B /* MovieListCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ECCE95720B0CCB400FE338B /* MovieListCollectionViewFlowLayout.swift */; };
 		2ECCE95E20B0EC4E00FE338B /* ConfigurationEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ECCE95D20B0EC4E00FE338B /* ConfigurationEntity.swift */; };
@@ -114,6 +115,7 @@
 		2E02A23420B4DF83008B93F5 /* AlamofireImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AlamofireImage.framework; path = Carthage/Build/iOS/AlamofireImage.framework; sourceTree = "<group>"; };
 		2E14CFBF20B0BDA2000E1724 /* SwiftMessages.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftMessages.framework; path = Carthage/Build/iOS/SwiftMessages.framework; sourceTree = "<group>"; };
 		2E14CFC120B0BDE4000E1724 /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		2E81458C211E582700F3E0A2 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		2EC1335D20B4F4A2004ABAD1 /* Mock+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mock+Extensions.swift"; sourceTree = "<group>"; };
 		2ECCE95720B0CCB400FE338B /* MovieListCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieListCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
 		2ECCE95D20B0EC4E00FE338B /* ConfigurationEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationEntity.swift; sourceTree = "<group>"; };
@@ -374,6 +376,7 @@
 				6557FE55209B52A6004DEC8D /* The_Movie_DB_ClientTests.swift */,
 				6557FE57209B52A6004DEC8D /* Info.plist */,
 				65F009AA20A92EAC00F4E363 /* movie_sample_data.json */,
+				2E81458C211E582700F3E0A2 /* TestHelpers.swift */,
 			);
 			path = "The Movie DB ClientTests";
 			sourceTree = "<group>";
@@ -813,6 +816,7 @@
 				6588D79120BF978C0090BB6F /* JsonHelper.swift in Sources */,
 				2EE3AAC520B27C2400C4CD6A /* MovieListMocks.swift in Sources */,
 				2E02A23120B4DD1F008B93F5 /* MovieDetailMocks.swift in Sources */,
+				2E81458D211E582700F3E0A2 /* TestHelpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/The Movie DB Client/App/ManagedObjectContextFactory.swift
+++ b/The Movie DB Client/App/ManagedObjectContextFactory.swift
@@ -9,7 +9,7 @@
 import CoreData
 
 final class ManagedObjectContextFactory {
-    static func make() -> NSManagedObjectContext? {
+    static func make() -> NSManagedObjectContext {
         return PersistentContainerFactory.make().viewContext
     }
 }

--- a/The Movie DB Client/App/ManagedObjectModelFactory.swift
+++ b/The Movie DB Client/App/ManagedObjectModelFactory.swift
@@ -9,7 +9,7 @@
 import CoreData
 
 final class ManagedObjectModelFactory {
-    static func make() -> NSManagedObjectModel? {
+    static func make() -> NSManagedObjectModel {
         return PersistentContainerFactory.make().managedObjectModel
     }
 }

--- a/The Movie DB Client/App/PersistentStoreCoordinatorFactory.swift
+++ b/The Movie DB Client/App/PersistentStoreCoordinatorFactory.swift
@@ -9,7 +9,7 @@
 import CoreData
 
 final class PersistenceStoreCoordinatorFactory {
-    static func make() -> NSPersistentStoreCoordinator? {
+    static func make() -> NSPersistentStoreCoordinator {
         return PersistentContainerFactory.make().persistentStoreCoordinator
     }
 }

--- a/The Movie DB Client/Entities/Movie+CoreDataProperties.swift
+++ b/The Movie DB Client/Entities/Movie+CoreDataProperties.swift
@@ -45,12 +45,12 @@ extension Movie {
         }
     }
 
-    public var remoteId: Int32? {
+    public var remoteId: Int? {
         get {
             willAccessValue(forKey: "remoteId")
             defer { didAccessValue(forKey: "remoteId") }
 
-            return primitiveValue(forKey: "remoteId") as? Int32
+            return primitiveValue(forKey: "remoteId") as? Int
         }
         set {
             willChangeValue(forKey: "remoteId")

--- a/The Movie DB Client/MovieList/DataManager/Local/MovieListLocalDataManager.swift
+++ b/The Movie DB Client/MovieList/DataManager/Local/MovieListLocalDataManager.swift
@@ -16,15 +16,10 @@ class MovieListLocalDataManager: MovieListLocalDataManagerInputProtocol {
         self.managedObjectContext = managedObjectContext
     }
 
-    func getTMDbApiConfiguration() throws -> ConfigurationEntity? {
-        let request: NSFetchRequest<TMDbApiConfiguration> = TMDbApiConfiguration.fetchRequest()
-        let localConfig = try managedObjectContext.fetch(request).first
+    func getConfigurationEntity() throws -> ConfigurationEntity {
+        let localConfig = try getTMDbApiConfigurationEntity()
 
-        if let localConfig = localConfig {
-            return ConfigurationEntity(from: localConfig)
-        } else {
-            return nil
-        }
+        return ConfigurationEntity(from: localConfig)
     }
 
     func searchMovie(forTitle title: String) throws -> [Movie] {

--- a/The Movie DB Client/MovieList/DataManager/Local/MovieListLocalDataManager.swift
+++ b/The Movie DB Client/MovieList/DataManager/Local/MovieListLocalDataManager.swift
@@ -10,7 +10,7 @@ import CoreData
 
 class MovieListLocalDataManager: MovieListLocalDataManagerInputProtocol {
 
-	let managedObjectContext:NSManagedObjectContext
+    fileprivate let managedObjectContext: NSManagedObjectContext
 
     init(managedObjectContext: NSManagedObjectContext) {
         self.managedObjectContext = managedObjectContext

--- a/The Movie DB Client/MovieList/DataManager/Local/MovieListLocalDataManager.swift
+++ b/The Movie DB Client/MovieList/DataManager/Local/MovieListLocalDataManager.swift
@@ -29,9 +29,12 @@ class MovieListLocalDataManager: MovieListLocalDataManagerInputProtocol {
     }
 
     func getNextMoviesReleases() throws -> [Movie] {
-        let request: NSFetchRequest<Movie> = NSFetchRequest(entityName: String(describing: Movie.self))
-
-        return try managedObjectContext.fetch(request)
+        do {
+            let request: NSFetchRequest<Movie> = Movie.fetchRequest()
+            return try managedObjectContext.fetch(request)
+        } catch {
+            throw PersistenceError.objectNotFound
+        }
     }
 
     func saveMovie(for movieUpcomingResponse: MovieUpcomingResponse) throws {

--- a/The Movie DB Client/MovieList/DataManager/Local/MovieListLocalDataManager.swift
+++ b/The Movie DB Client/MovieList/DataManager/Local/MovieListLocalDataManager.swift
@@ -46,16 +46,20 @@ class MovieListLocalDataManager: MovieListLocalDataManagerInputProtocol {
         do {
             movie = try getMovieEntity(for: movieUpcomingElement.id!)
         } catch is PersistenceError {
-            guard let newMovie =
-                NSEntityDescription.entity(forEntityName: "Movie", in: managedObjectContext) else {
-                    return
-            }
-            movie = Movie(entity: newMovie, insertInto: managedObjectContext)
+            movie = try createMovieEntity()
             movie.remoteId = movieUpcomingElement.id ?? -1
         }
 
         populateMovieEntity(movie, with: movieUpcomingElement)
         try managedObjectContext.save()
+    }
+
+    func createMovieEntity() throws -> Movie {
+        guard let newMovie = NSEntityDescription
+            .entity(forEntityName: "Movie", in: managedObjectContext) else {
+                throw PersistenceError.couldNotSaveObject
+        }
+        return Movie(entity: newMovie, insertInto: managedObjectContext)
     }
 
     func getMovieEntity(for id: Int) throws -> Movie {

--- a/The Movie DB Client/MovieList/DataManager/Local/MovieListLocalDataManager.swift
+++ b/The Movie DB Client/MovieList/DataManager/Local/MovieListLocalDataManager.swift
@@ -58,6 +58,7 @@ class MovieListLocalDataManager: MovieListLocalDataManagerInputProtocol {
             tempMovie.genreIds = movieUpcomingElement.genreIds as [NSNumber]
             tempMovie.voteAverage = movieUpcomingElement.voteAverage
             tempMovie.popularity = movieUpcomingElement.popularity
+            tempMovie.originalLanguage = movieUpcomingElement.originalLanguage
 
             try managedObjectContext.save()
         } else {
@@ -76,6 +77,7 @@ class MovieListLocalDataManager: MovieListLocalDataManagerInputProtocol {
                 movie.genreIds = movieUpcomingElement.genreIds as [NSNumber]
                 movie.voteAverage = movieUpcomingElement.voteAverage
                 movie.popularity = movieUpcomingElement.popularity
+                movie.originalLanguage = movieUpcomingElement.originalLanguage
 
                 try managedObjectContext.save()
             }

--- a/The Movie DB Client/MovieList/DataManager/Local/MovieListLocalDataManager.swift
+++ b/The Movie DB Client/MovieList/DataManager/Local/MovieListLocalDataManager.swift
@@ -10,7 +10,7 @@ import CoreData
 
 class MovieListLocalDataManager: MovieListLocalDataManagerInputProtocol {
 
-    fileprivate let managedObjectContext:NSManagedObjectContext
+	let managedObjectContext:NSManagedObjectContext
 
     init(managedObjectContext: NSManagedObjectContext) {
         self.managedObjectContext = managedObjectContext

--- a/The Movie DB Client/MovieList/DataManager/Local/MovieListLocalDataManager.swift
+++ b/The Movie DB Client/MovieList/DataManager/Local/MovieListLocalDataManager.swift
@@ -40,7 +40,7 @@ class MovieListLocalDataManager: MovieListLocalDataManagerInputProtocol {
         return try managedObjectContext.fetch(request)
     }
 
-    func saveMovie(forMovieUpcomingResponseElement movieUpcomingElement: MovieUpcomingResponse.ResultsElement) throws {
+    func saveMovie(for movieUpcomingElement: MovieUpcomingResponse.ResultsElement) throws {
         let request: NSFetchRequest<Movie> = NSFetchRequest(entityName: String(describing: Movie.self))
         request.predicate = NSPredicate(format: "remoteId == %d", movieUpcomingElement.id!)
         let fetched = try managedObjectContext.fetch(request)
@@ -53,8 +53,8 @@ class MovieListLocalDataManager: MovieListLocalDataManagerInputProtocol {
             tempMovie.backdropPath = movieUpcomingElement.backdropPath
             tempMovie.releaseDate = movieUpcomingElement.releaseDate
             tempMovie.originalTitle = movieUpcomingElement.originalTitle
-            tempMovie.video = NSNumber(booleanLiteral: movieUpcomingElement.video!)
-            tempMovie.adult = NSNumber(booleanLiteral: movieUpcomingElement.adult!)
+            tempMovie.video = NSNumber(booleanLiteral: movieUpcomingElement.video ?? false)
+            tempMovie.adult = NSNumber(booleanLiteral: movieUpcomingElement.adult ?? false)
             tempMovie.genreIds = movieUpcomingElement.genreIds as [NSNumber]
             tempMovie.voteAverage = movieUpcomingElement.voteAverage
             tempMovie.popularity = movieUpcomingElement.popularity
@@ -64,14 +64,15 @@ class MovieListLocalDataManager: MovieListLocalDataManagerInputProtocol {
             if let newMovie = NSEntityDescription.entity(forEntityName: "Movie",
                                                          in: managedObjectContext) {
                 let movie = Movie(entity: newMovie, insertInto: managedObjectContext)
-                movie.remoteId = Int32(movieUpcomingElement.id!)
+                movie.remoteId = movieUpcomingElement.id ?? -1
+                movie.title = movieUpcomingElement.title
                 movie.overview = movieUpcomingElement.overview
                 movie.posterPath = movieUpcomingElement.posterPath
                 movie.backdropPath = movieUpcomingElement.backdropPath
                 movie.releaseDate = movieUpcomingElement.releaseDate
                 movie.originalTitle = movieUpcomingElement.originalTitle
-                movie.video = NSNumber(booleanLiteral: movieUpcomingElement.video!)
-                movie.adult = NSNumber(booleanLiteral: movieUpcomingElement.adult!)
+                movie.video = NSNumber(booleanLiteral: movieUpcomingElement.video ?? false)
+                movie.adult = NSNumber(booleanLiteral: movieUpcomingElement.adult ?? false)
                 movie.genreIds = movieUpcomingElement.genreIds as [NSNumber]
                 movie.voteAverage = movieUpcomingElement.voteAverage
                 movie.popularity = movieUpcomingElement.popularity
@@ -81,13 +82,13 @@ class MovieListLocalDataManager: MovieListLocalDataManagerInputProtocol {
         }
     }
 
-    func saveMovie(forMovieUpcomingResponse movieUpcomingResponse: MovieUpcomingResponse) throws {
-        movieUpcomingResponse.results.map { resultsElement in
-            try? saveMovie(forMovieUpcomingResponseElement: resultsElement)
+    func saveMovie(for movieUpcomingResponse: MovieUpcomingResponse) throws {
+        movieUpcomingResponse.results.forEach { resultsElement in
+            try? saveMovie(for: resultsElement)
         }
     }
 
-    func saveTMDbApiConfiguration(forConfiguration configuration: TMDbApiConfigurationResponse) throws {
+    func saveTMDbApiConfiguration(for configuration: TMDbApiConfigurationResponse) throws {
         let request: NSFetchRequest<TMDbApiConfiguration> = NSFetchRequest(entityName: String(describing: TMDbApiConfiguration.self))
 
         let fetched = try managedObjectContext.fetch(request)

--- a/The Movie DB Client/MovieList/Interactor/MovieListInteractor.swift
+++ b/The Movie DB Client/MovieList/Interactor/MovieListInteractor.swift
@@ -26,7 +26,7 @@ extension MovieListInteractor: UpcomingMovieOutputProtocol {
         if let configurationResponse = configuration {
             configurationEntity = ConfigurationEntity(from: configurationResponse)
         } else {
-            configurationEntity = (try! localDatamanager?.getTMDbApiConfiguration())!
+            configurationEntity = (try! localDatamanager?.getConfigurationEntity())!
         }
 
         let movieList = movies.results.map { (movieResponse: MovieUpcomingResponse.ResultsElement) -> MovieEntity in
@@ -47,7 +47,7 @@ extension MovieListInteractor: UpcomingMovieOutputProtocol {
     func onError() {
         do {
             let movies: [Movie]? = try localDatamanager?.getNextMoviesReleases()
-            let configuration = try localDatamanager?.getTMDbApiConfiguration()
+            let configuration = try localDatamanager?.getConfigurationEntity()
 
             let movieEntityList = movies?.map { (movie: Movie) -> MovieEntity in
                 return MovieEntity(withLocalMovie: movie, withLocalConfiguration: configuration)

--- a/The Movie DB Client/MovieList/Interactor/MovieListInteractor.swift
+++ b/The Movie DB Client/MovieList/Interactor/MovieListInteractor.swift
@@ -35,7 +35,7 @@ extension MovieListInteractor: UpcomingMovieOutputProtocol {
         }
 
         do {
-            try localDatamanager?.saveMovie(forMovieUpcomingResponse: movies)
+            try localDatamanager?.saveMovie(for: movies)
 
         } catch {
             presenter?.onError()
@@ -65,6 +65,6 @@ extension MovieListInteractor: UpcomingMovieOutputProtocol {
 
 extension MovieListInteractor: TMDbApiConfigurationOutputProtocol {
     func onTMDbApiConfigurationRetrieved(_ config: TMDbApiConfigurationResponse) {
-        try! localDatamanager?.saveTMDbApiConfiguration(forConfiguration: config)
+        try! localDatamanager?.saveTMDbApiConfiguration(for: config)
     }
 }

--- a/The Movie DB Client/MovieList/Protocols/MovieListProtocols.swift
+++ b/The Movie DB Client/MovieList/Protocols/MovieListProtocols.swift
@@ -102,7 +102,7 @@ protocol MovieListLocalDataManagerInputProtocol: class {
 
     func getTMDbApiConfiguration() throws -> ConfigurationEntity?
 
-    func saveMovie(forMovieUpcomingResponse movieUpcomingResponse: MovieUpcomingResponse) throws
+    func saveMovie(for movieUpcomingResponse: MovieUpcomingResponse) throws
 
-    func saveTMDbApiConfiguration(forConfiguration configuration: TMDbApiConfigurationResponse) throws
+    func saveTMDbApiConfiguration(for configuration: TMDbApiConfigurationResponse) throws
 }

--- a/The Movie DB Client/MovieList/Protocols/MovieListProtocols.swift
+++ b/The Movie DB Client/MovieList/Protocols/MovieListProtocols.swift
@@ -100,7 +100,7 @@ protocol MovieListLocalDataManagerInputProtocol: class {
 
     func searchMovie(forTitle title: String) throws -> [Movie]
 
-    func getTMDbApiConfiguration() throws -> ConfigurationEntity?
+    func getConfigurationEntity() throws -> ConfigurationEntity
 
     func saveMovie(for movieUpcomingResponse: MovieUpcomingResponse) throws
 

--- a/The Movie DB Client/MovieList/WireFrame/MovieListWireFrame.swift
+++ b/The Movie DB Client/MovieList/WireFrame/MovieListWireFrame.swift
@@ -16,7 +16,8 @@ class MovieListWireFrame: MovieListWireFrameProtocol {
 
             let interactorUpcomingMovie: MovieListInteractorInputProtocol & UpcomingMovieOutputProtocol = MovieListInteractor()
 
-            let localDataManager: MovieListLocalDataManagerInputProtocol = MovieListLocalDataManager()
+            let localDataManager: MovieListLocalDataManagerInputProtocol =
+                MovieListLocalDataManager(managedObjectContext: CoreDataStore.managedObjectContext)
             let remoteDataManager: MovieListRemoteDataManagerInputProtocol = MovieListRemoteDataManager()
             let wireFrame: MovieListWireFrameProtocol = MovieListWireFrame()
 

--- a/The Movie DB ClientTests/Factories.swift
+++ b/The Movie DB ClientTests/Factories.swift
@@ -1,0 +1,123 @@
+//
+//  Factories.swift
+//  The Movie DB ClientTests
+//
+//  Created by Amadeu Cavalcante Filho on 08/09/18.
+//  Copyright © 2018 Amadeu Cavalcante Filho. All rights reserved.
+//
+
+@testable import The_Movie_DB_Client
+
+final class MovieUpcomingResponseFactory {
+    static public var LaDoceVita: MovieUpcomingResponse.ResultsElement {
+        return MovieUpcomingResponse.ResultsElement(
+            voteCount: 501,
+            id: 439,
+            video: false,
+            voteAverage: 8.1,
+            title: "La dolce vita",
+            popularity: 10.0,
+            posterPath: "/aU7WLwPVCOoonAPWOPBmZ8X0c3c.jpg",
+            originalLanguage: "it",
+            originalTitle: "La dolce vita",
+            genreIds: [35, 18],
+            backdropPath: "/b3ofp0vhkbKsrz2V44DimBRKkxf.jpg",
+            adult: false,
+            overview: "Episodic journey of an Italian journalist scouring Rome in search of love.",
+            releaseDate: "1960-02-05"
+        )
+    }
+
+    static public var AvengersInfinityWar: MovieUpcomingResponse.ResultsElement {
+        return MovieUpcomingResponse.ResultsElement(
+            voteCount: 7745,
+            id: 299536,
+            video: false,
+            voteAverage: 8.3,
+            title: "Avengers: Infinity War",
+            popularity: 260.161,
+            posterPath: "/7WsyChQLEftFiDOVTGkv3hFpyyt.jpg",
+            originalLanguage: "it",
+            originalTitle: "La dolce vita",
+            genreIds: [35, 18],
+            backdropPath: "/bOGkgRGdhrBYJSLpXaxhXVstddV.jpg",
+            adult: false,
+            overview: """
+            As the Avengers and their allies have continued to protect the world from threats too large
+            for any one hero to handle, a new danger has emerged from the cosmic shadows: Thanos.
+            A despot of intergalactic infamy, his goal is to collect all six Infinity Stones,
+            artifacts of unimaginable power, and use them to inflict his twisted will on all of reality.
+            Everything the Avengers have fought for has led up to this moment -
+            the fate of Earth and existence itself has never been more uncertain.
+            """,
+            releaseDate: "1960-02-05"
+        )
+    }
+
+    public static var MoviesUpcoming: MovieUpcomingResponse {
+        return MovieUpcomingResponse(
+            results: [MovieUpcomingResponseFactory.AvengersInfinityWar,
+                      MovieUpcomingResponseFactory.LaDoceVita],
+            page: 1,
+            totalResults: 2,
+            dates: MovieUpcomingResponse.Dates.mocked,
+            totalPages: 1)
+    }
+}
+
+final class TMDbApiConfigurationFactory {
+    public static var Config: TMDbApiConfigurationResponse {
+        return TMDbApiConfigurationResponse(
+            images: Images,
+            changeKeys: ["adult",
+                         "air_date",
+                         "also_known_as",
+                         "alternative_titles",
+                         "biography",
+                         "birthday",
+                         "budget",
+                         "cast",
+                         "certifications",
+                         "character_names",
+                         "created_by",
+                         "crew",
+                         "deathday",
+                         "episode",
+                         "episode_number",
+                         "episode_run_time",
+                         "freebase_id",
+                         "freebase_mid",])
+    }
+
+    public static var Images: TMDbApiConfigurationResponse.Images {
+        return TMDbApiConfigurationResponse.Images(
+            baseUrl: "http://image.tmdb.org/t/p/",
+            secureBaseUrl: "https://image.tmdb.org/t/p/",
+            backdropSizes: ["w300",
+                            "w780",
+                            "w1280",
+                            "original"],
+            logoSizes: ["w45",
+                        "w92",
+                        "w154",
+                        "w185",
+                        "w300",
+                        "w500",
+                        "original"],
+            posterSizes: ["w92",
+                          "w154",
+                          "w185",
+                          "w342",
+                          "w500",
+                          "w780",
+                          "original"],
+            profileSizes: ["w45",
+                           "w185",
+                           "h632",
+                           "original"],
+            stillSizes: ["w92",
+                         "w185",
+                         "w300",
+                         "original"])
+    }
+}

--- a/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
+++ b/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
@@ -38,42 +38,42 @@ final class LocalDataManagerTest: XCTestCase {
     }
 
     func testSaveMovieResponseUpcoming() throws {
-        let mokedMovieResponse = MovieUpcomingResponse.mocked
+        let moviesUpcoming = MovieUpcomingResponseFactory.MoviesUpcoming
 
         NotificationCenter.default.addObserver(
-            forName: .NSManagedObjectContextObjectsDidChange,
+            forName: .NSManagedObjectContextDidSave,
             object: inMemoryManagedObjectContext,
             queue: nil) { (notification) in
-                guard let insertedMovie = self.getInsertedMovie(from: notification) as? Movie else {
+                guard let insertedMovie = self.getInsertedMovie(from: notification) else {
                         XCTFail()
                         return
                 }
 
                 self.coreDataExpectation.fulfill()
-                XCTAssertTrue(mokedMovieResponse.results.first! == insertedMovie)
+                XCTAssertTrue(moviesUpcoming.results.first! == insertedMovie)
         }
 
-        try localDataManager.saveMovie(for: mokedMovieResponse)
+        try localDataManager.saveMovie(for: moviesUpcoming)
         wait(for: [coreDataExpectation], timeout: 1)
     }
 
     func testSaveMovieUpcomingElementLocally() throws {
-        let mokedMovieElementResponse = MovieUpcomingResponse.ResultsElement.mocked2
+        let movieLaDoceVita = MovieUpcomingResponseFactory.LaDoceVita
 
         NotificationCenter.default.addObserver(
-            forName: .NSManagedObjectContextObjectsDidChange,
+            forName: .NSManagedObjectContextDidSave,
             object: inMemoryManagedObjectContext,
             queue: nil) { (notification) in
-                guard let insertedMovie = self.getInsertedMovie(from: notification) as? Movie else {
+                guard let insertedMovie = self.getInsertedMovie(from: notification) else {
                     XCTFail()
                     return
                 }
 
                 self.coreDataExpectation.fulfill()
-                XCTAssertTrue(mokedMovieElementResponse == insertedMovie)
+                XCTAssertTrue(movieLaDoceVita == insertedMovie)
         }
 
-        try localDataManager.saveMovie(for: mokedMovieElementResponse)
+        try localDataManager.saveMovie(for: movieLaDoceVita)
         wait(for: [coreDataExpectation], timeout: 1)
     }
 }

--- a/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
+++ b/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
@@ -12,53 +12,58 @@ import Foundation
 @testable import The_Movie_DB_Client
 
 final class LocalDataManagerTest: XCTestCase {
-	fileprivate var localDataManager: MovieListLocalDataManager!
-	private var coreDataExpectation: XCTestExpectation!
+    fileprivate var localDataManager: MovieListLocalDataManager!
+    fileprivate var inMemoryManagedObjectContext: NSManagedObjectContext!
+    private var coreDataExpectation: XCTestExpectation!
 
+    override func setUp() {
+        super.setUp()
+        let testResources = MovieListLocalDataManager.testResources
+        localDataManager = testResources.localDataManager
+        inMemoryManagedObjectContext = testResources.managedObjectContext
+        coreDataExpectation = self.expectation(description: "Core data actions")
+    }
 
-	override func setUp() {
-		super.setUp()
-		localDataManager = MovieListLocalDataManager.inMemoryLocalDataManager
-		coreDataExpectation = self.expectation(description: "Core data actions")
-	}
+    override func tearDown() {
+        super.tearDown()
+    }
 
-	override func tearDown() {
-		super.tearDown()
-	}
+    func testSaveMovieResponseUpcoming() throws {
+        let mokedMovieResponse = MovieUpcomingResponse.mocked
 
-	func testSaveMovieUpcomingLocally() throws {
-		let mokedMovieResponse = MovieUpcomingResponse.mocked
-		let count = try localDataManager.getNextMoviesReleases().count
+        wait(for: [coreDataExpectation], timeout: 2)
 
-		wait(for: [coreDataExpectation], timeout: 2)
+        NotificationCenter.default
+            .addObserver(forName: .NSManagedObjectContextObjectsDidChange,
+                         object: inMemoryManagedObjectContext,
+                         queue: nil) { (notification) in
+                            guard let userInfo = notification.userInfo else {
+                                XCTFail()
+                                return
+                            }
 
-		NotificationCenter.default
-			.addObserver(forName: .NSManagedObjectContextObjectsDidChange,
-						 object: localDataManager.managedObjectContext,
-						 queue: nil) { (notification) in
-							guard let userInfo = notification.userInfo else {
-								XCTFail()
-								return
-							}
+                            guard
+                                let inserts = userInfo[NSInsertedObjectsKey] as? Set<NSManagedObject>,
+                                let insertedMovie = inserts.first as! Movie! else {
+                                    XCTFail()
+                                    return
+                            }
+                            self.coreDataExpectation.fulfill()
+//                            XCTAssertEqual(Int(insertedMovie.remoteId!), mokedMovieResponse.results.first!.id!)
+        }
 
-							if let inserts = userInfo[NSInsertedObjectsKey] as? Set<NSManagedObject> {
-								print(inserts)
-							}
-							self.coreDataExpectation.fulfill()
-		}
+        try localDataManager.saveMovie(forMovieUpcomingResponse: mokedMovieResponse)
+    }
 
-		try localDataManager.saveMovie(forMovieUpcomingResponse: mokedMovieResponse)
-	}
+    func testSaveMovieUpcomingElementLocally() throws {
+        var mokedMovieResponseElement = MovieUpcomingResponse.ResultsElement.mocked
+        let count = try localDataManager.getNextMoviesReleases().count
 
-	func testSaveMovieUpcomingElementLocally() throws {
-		var mokedMovieResponseElement = MovieUpcomingResponse.ResultsElement.mocked
-		let count = try localDataManager.getNextMoviesReleases().count
+        try localDataManager.saveMovie(forMovieUpcomingResponseElement: mokedMovieResponseElement)
 
-		try localDataManager.saveMovie(forMovieUpcomingResponseElement: mokedMovieResponseElement)
+        let moviesStored = try localDataManager.getNextMoviesReleases()
 
-		let moviesStored = try localDataManager.getNextMoviesReleases()
-
-		XCTAssertEqual(mokedMovieResponseElement.id, Int(moviesStored[0].remoteId!))
-		XCTAssertEqual(mokedMovieResponseElement.adult, moviesStored[0].adult!.boolValue)
-	}
+        XCTAssertEqual(mokedMovieResponseElement.id, Int(moviesStored[0].remoteId!))
+        XCTAssertEqual(mokedMovieResponseElement.adult, moviesStored[0].adult!.boolValue)
+    }
 }

--- a/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
+++ b/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
@@ -31,39 +31,78 @@ final class LocalDataManagerTest: XCTestCase {
     func testSaveMovieResponseUpcoming() throws {
         let mokedMovieResponse = MovieUpcomingResponse.mocked
 
-        wait(for: [coreDataExpectation], timeout: 2)
+        NotificationCenter.default.addObserver(
+            forName: .NSManagedObjectContextObjectsDidChange,
+            object: inMemoryManagedObjectContext,
+            queue: nil) { (notification) in
+                guard let userInfo = notification.userInfo else {
+                    XCTFail()
+                    return
+                }
 
-        NotificationCenter.default
-            .addObserver(forName: .NSManagedObjectContextObjectsDidChange,
-                         object: inMemoryManagedObjectContext,
-                         queue: nil) { (notification) in
-                            guard let userInfo = notification.userInfo else {
-                                XCTFail()
-                                return
-                            }
+                guard let inserts = userInfo[NSInsertedObjectsKey] as? Set<NSManagedObject> else {
+                    XCTFail()
+                    return
+                }
 
-                            guard
-                                let inserts = userInfo[NSInsertedObjectsKey] as? Set<NSManagedObject>,
-                                let insertedMovie = inserts.first as! Movie! else {
-                                    XCTFail()
-                                    return
-                            }
-                            self.coreDataExpectation.fulfill()
-//                            XCTAssertEqual(Int(insertedMovie.remoteId!), mokedMovieResponse.results.first!.id!)
+                guard let insertedMovie = inserts.first as? Movie else {
+                    XCTFail()
+                    return
+                }
+
+                self.coreDataExpectation.fulfill()
+                XCTAssertEqual(insertedMovie.remoteId!, mokedMovieResponse.results.first!.id!)
+                XCTAssertEqual(insertedMovie.title, mokedMovieResponse.results.first!.title)
+                XCTAssertEqual(insertedMovie.originalTitle, mokedMovieResponse.results.first!.originalTitle)
+                XCTAssertEqual(insertedMovie.overview, mokedMovieResponse.results.first!.overview)
+                XCTAssertEqual(insertedMovie.posterPath, mokedMovieResponse.results.first!.posterPath)
+                XCTAssertEqual(insertedMovie.backdropPath, mokedMovieResponse.results.first!.backdropPath)
+                XCTAssertEqual(insertedMovie.releaseDate, mokedMovieResponse.results.first!.releaseDate)
+                XCTAssertEqual(insertedMovie.adult!.boolValue, mokedMovieResponse.results.first!.adult)
+                XCTAssertEqual(insertedMovie.video!.boolValue, mokedMovieResponse.results.first!.video)
+                XCTAssertEqual(insertedMovie.popularity, mokedMovieResponse.results.first!.popularity)
         }
 
-        try localDataManager.saveMovie(forMovieUpcomingResponse: mokedMovieResponse)
+        try localDataManager.saveMovie(for: mokedMovieResponse)
+        wait(for: [coreDataExpectation], timeout: 1)
     }
 
     func testSaveMovieUpcomingElementLocally() throws {
-        var mokedMovieResponseElement = MovieUpcomingResponse.ResultsElement.mocked
-        let count = try localDataManager.getNextMoviesReleases().count
+        let mokedMovieElementResponse = MovieUpcomingResponse.ResultsElement.mocked2
 
-        try localDataManager.saveMovie(forMovieUpcomingResponseElement: mokedMovieResponseElement)
+        NotificationCenter.default.addObserver(
+            forName: .NSManagedObjectContextObjectsDidChange,
+            object: inMemoryManagedObjectContext,
+            queue: nil) { (notification) in
+                guard let userInfo = notification.userInfo else {
+                    XCTFail()
+                    return
+                }
 
-        let moviesStored = try localDataManager.getNextMoviesReleases()
+                guard let inserts = userInfo[NSInsertedObjectsKey] as? Set<NSManagedObject> else {
+                    XCTFail()
+                    return
+                }
 
-        XCTAssertEqual(mokedMovieResponseElement.id, Int(moviesStored[0].remoteId!))
-        XCTAssertEqual(mokedMovieResponseElement.adult, moviesStored[0].adult!.boolValue)
+                guard let insertedMovie = inserts.first as? Movie else {
+                    XCTFail()
+                    return
+                }
+
+                self.coreDataExpectation.fulfill()
+                XCTAssertEqual(insertedMovie.remoteId!, mokedMovieElementResponse.id!)
+                XCTAssertEqual(insertedMovie.adult!.boolValue, mokedMovieElementResponse.adult)
+                XCTAssertEqual(insertedMovie.video!.boolValue, mokedMovieElementResponse.video)
+                XCTAssertEqual(insertedMovie.title, mokedMovieElementResponse.title)
+                XCTAssertEqual(insertedMovie.originalTitle, mokedMovieElementResponse.originalTitle)
+                XCTAssertEqual(insertedMovie.overview, mokedMovieElementResponse.overview)
+                XCTAssertEqual(insertedMovie.backdropPath, mokedMovieElementResponse.backdropPath)
+                XCTAssertEqual(insertedMovie.posterPath, mokedMovieElementResponse.posterPath)
+                XCTAssertEqual(insertedMovie.popularity, mokedMovieElementResponse.popularity)
+                XCTAssertEqual(insertedMovie.releaseDate, mokedMovieElementResponse.releaseDate)
+        }
+
+        try localDataManager.saveMovie(for: mokedMovieElementResponse)
+        wait(for: [coreDataExpectation], timeout: 1)
     }
 }

--- a/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
+++ b/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
@@ -39,6 +39,23 @@ final class LocalDataManagerTest: XCTestCase {
         wait(for: [coreDataExpectation], timeout: 1)
     }
 
+    func testGetNextMoviesReleases() throws {
+        let moviesUpcoming = MovieUpcomingResponseFactory.MoviesUpcoming
+        try localDataManager.saveMovie(for: moviesUpcoming)
+
+        let nextMoviesRleases = try localDataManager.getNextMoviesReleases()
+
+        XCTAssertEqual(2, nextMoviesRleases.count)
+        XCTAssertTrue(moviesUpcoming.results[0] == nextMoviesRleases[0])
+        XCTAssertTrue(moviesUpcoming.results[1] == nextMoviesRleases[1])
+    }
+
+    func testGetNextMoviesReleasesWhenLocalStorageIsEmpty() throws {
+        let nextMoviesRleases = try localDataManager.getNextMoviesReleases()
+
+        XCTAssertEqual(0, nextMoviesRleases.count)
+    }
+
     func testSaveMovieUpcomingElement() throws {
         let coreDataExpectation = self.expectation(description: "Core data actions")
         let movieLaDoceVita = MovieUpcomingResponseFactory.LaDoceVita

--- a/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
+++ b/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
@@ -69,9 +69,16 @@ final class LocalDataManagerTest: XCTestCase {
         let configurationApiResponse = TMDbApiConfigurationFactory.Config
         try localDataManager.saveTMDbApiConfiguration(for: configurationApiResponse)
 
-        let configurationEntity = (try localDataManager.getTMDbApiConfiguration())!
+        let configurationEntity = try localDataManager.getConfigurationEntity()
 
         XCTAssertTrue(configurationEntity == configurationApiResponse)
+    }
+
+    func testGetSavedTMDbApiConfigurationWhenLocalStorageIsEmpty() throws {
+
+        XCTAssertThrowsError(try localDataManager.getConfigurationEntity()) { (error) in
+            XCTAssertEqual(error as! PersistenceError, .objectNotFound)
+        }
     }
 
     fileprivate func getInserted<T>(_ type: T.Type, from notification: Notification) -> T? {

--- a/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
+++ b/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
@@ -28,6 +28,15 @@ final class LocalDataManagerTest: XCTestCase {
         super.tearDown()
     }
 
+    fileprivate func getInsertedMovie(from notification: Notification) -> Movie? {
+        guard let userInfo = notification.userInfo,
+            let inserts = userInfo[NSInsertedObjectsKey] as? Set<NSManagedObject>,
+            let insertedMovie = inserts.first as? Movie else {
+                return nil
+        }
+        return insertedMovie
+    }
+
     func testSaveMovieResponseUpcoming() throws {
         let mokedMovieResponse = MovieUpcomingResponse.mocked
 
@@ -35,9 +44,7 @@ final class LocalDataManagerTest: XCTestCase {
             forName: .NSManagedObjectContextObjectsDidChange,
             object: inMemoryManagedObjectContext,
             queue: nil) { (notification) in
-                guard let userInfo = notification.userInfo,
-                    let inserts = userInfo[NSInsertedObjectsKey] as? Set<NSManagedObject>,
-                    let insertedMovie = inserts.first as? Movie else {
+                guard let insertedMovie = self.getInsertedMovie(from: notification) as? Movie else {
                         XCTFail()
                         return
                 }
@@ -57,11 +64,9 @@ final class LocalDataManagerTest: XCTestCase {
             forName: .NSManagedObjectContextObjectsDidChange,
             object: inMemoryManagedObjectContext,
             queue: nil) { (notification) in
-                guard let userInfo = notification.userInfo,
-                    let inserts = userInfo[NSInsertedObjectsKey] as? Set<NSManagedObject>,
-                    let insertedMovie = inserts.first as? Movie else {
-                        XCTFail()
-                        return
+                guard let insertedMovie = self.getInsertedMovie(from: notification) as? Movie else {
+                    XCTFail()
+                    return
                 }
 
                 self.coreDataExpectation.fulfill()

--- a/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
+++ b/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
@@ -35,32 +35,15 @@ final class LocalDataManagerTest: XCTestCase {
             forName: .NSManagedObjectContextObjectsDidChange,
             object: inMemoryManagedObjectContext,
             queue: nil) { (notification) in
-                guard let userInfo = notification.userInfo else {
-                    XCTFail()
-                    return
-                }
-
-                guard let inserts = userInfo[NSInsertedObjectsKey] as? Set<NSManagedObject> else {
-                    XCTFail()
-                    return
-                }
-
-                guard let insertedMovie = inserts.first as? Movie else {
-                    XCTFail()
-                    return
+                guard let userInfo = notification.userInfo,
+                    let inserts = userInfo[NSInsertedObjectsKey] as? Set<NSManagedObject>,
+                    let insertedMovie = inserts.first as? Movie else {
+                        XCTFail()
+                        return
                 }
 
                 self.coreDataExpectation.fulfill()
-                XCTAssertEqual(insertedMovie.remoteId!, mokedMovieResponse.results.first!.id!)
-                XCTAssertEqual(insertedMovie.title, mokedMovieResponse.results.first!.title)
-                XCTAssertEqual(insertedMovie.originalTitle, mokedMovieResponse.results.first!.originalTitle)
-                XCTAssertEqual(insertedMovie.overview, mokedMovieResponse.results.first!.overview)
-                XCTAssertEqual(insertedMovie.posterPath, mokedMovieResponse.results.first!.posterPath)
-                XCTAssertEqual(insertedMovie.backdropPath, mokedMovieResponse.results.first!.backdropPath)
-                XCTAssertEqual(insertedMovie.releaseDate, mokedMovieResponse.results.first!.releaseDate)
-                XCTAssertEqual(insertedMovie.adult!.boolValue, mokedMovieResponse.results.first!.adult)
-                XCTAssertEqual(insertedMovie.video!.boolValue, mokedMovieResponse.results.first!.video)
-                XCTAssertEqual(insertedMovie.popularity, mokedMovieResponse.results.first!.popularity)
+                XCTAssertTrue(mokedMovieResponse.results.first! == insertedMovie)
         }
 
         try localDataManager.saveMovie(for: mokedMovieResponse)
@@ -74,32 +57,15 @@ final class LocalDataManagerTest: XCTestCase {
             forName: .NSManagedObjectContextObjectsDidChange,
             object: inMemoryManagedObjectContext,
             queue: nil) { (notification) in
-                guard let userInfo = notification.userInfo else {
-                    XCTFail()
-                    return
-                }
-
-                guard let inserts = userInfo[NSInsertedObjectsKey] as? Set<NSManagedObject> else {
-                    XCTFail()
-                    return
-                }
-
-                guard let insertedMovie = inserts.first as? Movie else {
-                    XCTFail()
-                    return
+                guard let userInfo = notification.userInfo,
+                    let inserts = userInfo[NSInsertedObjectsKey] as? Set<NSManagedObject>,
+                    let insertedMovie = inserts.first as? Movie else {
+                        XCTFail()
+                        return
                 }
 
                 self.coreDataExpectation.fulfill()
-                XCTAssertEqual(insertedMovie.remoteId!, mokedMovieElementResponse.id!)
-                XCTAssertEqual(insertedMovie.adult!.boolValue, mokedMovieElementResponse.adult)
-                XCTAssertEqual(insertedMovie.video!.boolValue, mokedMovieElementResponse.video)
-                XCTAssertEqual(insertedMovie.title, mokedMovieElementResponse.title)
-                XCTAssertEqual(insertedMovie.originalTitle, mokedMovieElementResponse.originalTitle)
-                XCTAssertEqual(insertedMovie.overview, mokedMovieElementResponse.overview)
-                XCTAssertEqual(insertedMovie.backdropPath, mokedMovieElementResponse.backdropPath)
-                XCTAssertEqual(insertedMovie.posterPath, mokedMovieElementResponse.posterPath)
-                XCTAssertEqual(insertedMovie.popularity, mokedMovieElementResponse.popularity)
-                XCTAssertEqual(insertedMovie.releaseDate, mokedMovieElementResponse.releaseDate)
+                XCTAssertTrue(mokedMovieElementResponse == insertedMovie)
         }
 
         try localDataManager.saveMovie(for: mokedMovieElementResponse)

--- a/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
+++ b/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
@@ -7,8 +7,58 @@
 //
 
 import XCTest
+import CoreData
+import Foundation
 @testable import The_Movie_DB_Client
 
 final class LocalDataManagerTest: XCTestCase {
+	fileprivate var localDataManager: MovieListLocalDataManager!
+	private var coreDataExpectation: XCTestExpectation!
 
+
+	override func setUp() {
+		super.setUp()
+		localDataManager = MovieListLocalDataManager.inMemoryLocalDataManager
+		coreDataExpectation = self.expectation(description: "Core data actions")
+	}
+
+	override func tearDown() {
+		super.tearDown()
+	}
+
+	func testSaveMovieUpcomingLocally() throws {
+		let mokedMovieResponse = MovieUpcomingResponse.mocked
+		let count = try localDataManager.getNextMoviesReleases().count
+
+		wait(for: [coreDataExpectation], timeout: 2)
+
+		NotificationCenter.default
+			.addObserver(forName: .NSManagedObjectContextObjectsDidChange,
+						 object: localDataManager.managedObjectContext,
+						 queue: nil) { (notification) in
+							guard let userInfo = notification.userInfo else {
+								XCTFail()
+								return
+							}
+
+							if let inserts = userInfo[NSInsertedObjectsKey] as? Set<NSManagedObject> {
+								print(inserts)
+							}
+							self.coreDataExpectation.fulfill()
+		}
+
+		try localDataManager.saveMovie(forMovieUpcomingResponse: mokedMovieResponse)
+	}
+
+	func testSaveMovieUpcomingElementLocally() throws {
+		var mokedMovieResponseElement = MovieUpcomingResponse.ResultsElement.mocked
+		let count = try localDataManager.getNextMoviesReleases().count
+
+		try localDataManager.saveMovie(forMovieUpcomingResponseElement: mokedMovieResponseElement)
+
+		let moviesStored = try localDataManager.getNextMoviesReleases()
+
+		XCTAssertEqual(mokedMovieResponseElement.id, Int(moviesStored[0].remoteId!))
+		XCTAssertEqual(mokedMovieResponseElement.adult, moviesStored[0].adult!.boolValue)
+	}
 }

--- a/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
+++ b/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
@@ -39,7 +39,7 @@ final class LocalDataManagerTest: XCTestCase {
         wait(for: [coreDataExpectation], timeout: 1)
     }
 
-    func testSaveMovieUpcomingElementLocally() throws {
+    func testSaveMovieUpcomingElement() throws {
         let coreDataExpectation = self.expectation(description: "Core data actions")
         let movieLaDoceVita = MovieUpcomingResponseFactory.LaDoceVita
 

--- a/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
+++ b/The Movie DB ClientTests/MovieList/LocalDataManagerTest.swift
@@ -28,6 +28,24 @@ final class LocalDataManagerTest: XCTestCase {
         super.tearDown()
     }
 
+    func testSaveMovieResponseUpcoming() throws {
+        let moviesUpcoming = MovieUpcomingResponseFactory.MoviesUpcoming
+
+        observeInsertedMovie(isEqualto: moviesUpcoming.results[0])
+
+        try localDataManager.saveMovie(for: moviesUpcoming)
+        wait(for: [coreDataExpectation], timeout: 1)
+    }
+
+    func testSaveMovieUpcomingElementLocally() throws {
+        let movieLaDoceVita = MovieUpcomingResponseFactory.LaDoceVita
+
+        observeInsertedMovie(isEqualto: movieLaDoceVita)
+
+        try localDataManager.saveMovie(for: movieLaDoceVita)
+        wait(for: [coreDataExpectation], timeout: 1)
+    }
+
     fileprivate func getInsertedMovie(from notification: Notification) -> Movie? {
         guard let userInfo = notification.userInfo,
             let inserts = userInfo[NSInsertedObjectsKey] as? Set<NSManagedObject>,
@@ -37,29 +55,7 @@ final class LocalDataManagerTest: XCTestCase {
         return insertedMovie
     }
 
-    func testSaveMovieResponseUpcoming() throws {
-        let moviesUpcoming = MovieUpcomingResponseFactory.MoviesUpcoming
-
-        NotificationCenter.default.addObserver(
-            forName: .NSManagedObjectContextDidSave,
-            object: inMemoryManagedObjectContext,
-            queue: nil) { (notification) in
-                guard let insertedMovie = self.getInsertedMovie(from: notification) else {
-                        XCTFail()
-                        return
-                }
-
-                self.coreDataExpectation.fulfill()
-                XCTAssertTrue(moviesUpcoming.results.first! == insertedMovie)
-        }
-
-        try localDataManager.saveMovie(for: moviesUpcoming)
-        wait(for: [coreDataExpectation], timeout: 1)
-    }
-
-    func testSaveMovieUpcomingElementLocally() throws {
-        let movieLaDoceVita = MovieUpcomingResponseFactory.LaDoceVita
-
+    fileprivate func observeInsertedMovie(isEqualto movieResponse: MovieUpcomingResponse.ResultsElement) {
         NotificationCenter.default.addObserver(
             forName: .NSManagedObjectContextDidSave,
             object: inMemoryManagedObjectContext,
@@ -70,10 +66,7 @@ final class LocalDataManagerTest: XCTestCase {
                 }
 
                 self.coreDataExpectation.fulfill()
-                XCTAssertTrue(movieLaDoceVita == insertedMovie)
+                XCTAssertTrue(movieResponse == insertedMovie)
         }
-
-        try localDataManager.saveMovie(for: movieLaDoceVita)
-        wait(for: [coreDataExpectation], timeout: 1)
     }
 }

--- a/The Movie DB ClientTests/MovieList/MovieListMocks.swift
+++ b/The Movie DB ClientTests/MovieList/MovieListMocks.swift
@@ -123,9 +123,9 @@ final class MovieListMocks {
             return movies
         }
 
-        func getTMDbApiConfiguration() throws -> ConfigurationEntity? {
+        func getConfigurationEntity() throws -> ConfigurationEntity {
             fetchTMDbApiConfigurationInvoked = true
-            return configurationEntity
+            return configurationEntity!
         }
 
         func saveMovie(for movieUpcomingResponse: MovieUpcomingResponse) throws {

--- a/The Movie DB ClientTests/MovieList/MovieListMocks.swift
+++ b/The Movie DB ClientTests/MovieList/MovieListMocks.swift
@@ -128,12 +128,12 @@ final class MovieListMocks {
             return configurationEntity
         }
 
-        func saveMovie(forMovieUpcomingResponse movieUpcomingResponse: MovieUpcomingResponse) throws {
+        func saveMovie(for movieUpcomingResponse: MovieUpcomingResponse) throws {
             saveMovieInvoked = true
             saveMovieParameters = movieUpcomingResponse
         }
 
-        func saveTMDbApiConfiguration(forConfiguration configuration: TMDbApiConfigurationResponse) throws {
+        func saveTMDbApiConfiguration(for configuration: TMDbApiConfigurationResponse) throws {
             saveTMDbApiConfigurationInvoked = true
             saveTMDbApiConfigurationParameters = configuration
         }

--- a/The Movie DB ClientTests/TestHelpers.swift
+++ b/The Movie DB ClientTests/TestHelpers.swift
@@ -21,75 +21,56 @@ extension MovieListLocalDataManager {
     }
 }
 
-extension MovieUpcomingResponse.ResultsElement {
-    static var mocked: MovieUpcomingResponse.ResultsElement {
+final class MovieUpcomingResponseFactory {
+    static public var LaDoceVita: MovieUpcomingResponse.ResultsElement {
         return MovieUpcomingResponse.ResultsElement(
-            voteCount: 1,
-            id: 1,
+            voteCount: 501,
+            id: 439,
             video: false,
-            voteAverage: 10.0,
-            title: "My Title",
+            voteAverage: 8.1,
+            title: "La dolce vita",
             popularity: 10.0,
-            posterPath: "my/path/to/poster",
-            originalLanguage: "en",
-            originalTitle: "My original Title",
-            genreIds: [1, 2, 3, 4],
-            backdropPath: "my/path/to/poster",
+            posterPath: "/aU7WLwPVCOoonAPWOPBmZ8X0c3c.jpg",
+            originalLanguage: "it",
+            originalTitle: "La dolce vita",
+            genreIds: [35, 18],
+            backdropPath: "/b3ofp0vhkbKsrz2V44DimBRKkxf.jpg",
             adult: false,
-            overview: "movie mock overview",
-            releaseDate: "2018-04-05"
-        )
-    }
-
-    static var mocked2: MovieUpcomingResponse.ResultsElement {
-        return MovieUpcomingResponse.ResultsElement(
-            voteCount: 10,
-            id: 81,
-            video: false,
-            voteAverage: 100.0,
-            title: "The Sweet Life",
-            popularity: 999.0,
-            posterPath: "la/dolce/to/la/vita",
-            originalLanguage: "en",
-            originalTitle: "La Dolce Vita",
-            genreIds: [14, 23, 13, 41],
-            backdropPath: "my/path/to/poster",
-            adult: true,
-            overview: "movie mock overview",
+            overview: "Episodic journey of an Italian journalist scouring Rome in search of love.",
             releaseDate: "1960-02-05"
         )
     }
-}
 
-func == (lhs: MovieUpcomingResponse.ResultsElement, rhs: Movie) -> Bool {
-    return
-        lhs.id == rhs.remoteId &&
-            lhs.adult! == rhs.adult!.boolValue &&
-            lhs.video! == rhs.video!.boolValue &&
-            lhs.backdropPath! == rhs.backdropPath! &&
-            lhs.title! == rhs.title! &&
-            lhs.posterPath! == rhs.posterPath! &&
-            lhs.overview! == rhs.overview! &&
-            lhs.originalTitle! == rhs.originalTitle! &&
-            lhs.popularity! == rhs.popularity! &&
-            lhs.originalLanguage! == rhs.originalLanguage! &&
-            lhs.releaseDate! == rhs.releaseDate! &&
-            lhs.genreIds == rhs.genreIds.map { $0.intValue }
-}
-
-extension MovieUpcomingResponse {
-    static var mocked: MovieUpcomingResponse {
-        return MovieUpcomingResponse(
-            results: [MovieUpcomingResponse.ResultsElement.mocked],
-            page: 1,
-            totalResults: 1,
-            dates: nil,
-            totalPages: 1)
+    static public var AvengersInfinityWar: MovieUpcomingResponse.ResultsElement {
+        return MovieUpcomingResponse.ResultsElement(
+            voteCount: 7745,
+            id: 299536,
+            video: false,
+            voteAverage: 8.3,
+            title: "Avengers: Infinity War",
+            popularity: 260.161,
+            posterPath: "/7WsyChQLEftFiDOVTGkv3hFpyyt.jpg",
+            originalLanguage: "it",
+            originalTitle: "La dolce vita",
+            genreIds: [35, 18],
+            backdropPath: "/bOGkgRGdhrBYJSLpXaxhXVstddV.jpg",
+            adult: false,
+            overview: """
+            As the Avengers and their allies have continued to protect the world from threats too large
+            for any one hero to handle, a new danger has emerged from the cosmic shadows: Thanos.
+            A despot of intergalactic infamy, his goal is to collect all six Infinity Stones,
+            artifacts of unimaginable power, and use them to inflict his twisted will on all of reality.
+            Everything the Avengers have fought for has led up to this moment -
+            the fate of Earth and existence itself has never been more uncertain.
+            """,
+            releaseDate: "1960-02-05"
+        )
     }
 
-    static var mockedWithTwoElements: MovieUpcomingResponse {
+    public static var MoviesUpcoming: MovieUpcomingResponse {
         return MovieUpcomingResponse(
-            results: [MovieUpcomingResponse.ResultsElement.mocked, MovieUpcomingResponse.ResultsElement.mocked2],
+            results: [MovieUpcomingResponseFactory.AvengersInfinityWar,
+                      MovieUpcomingResponseFactory.LaDoceVita],
             page: 1,
             totalResults: 2,
             dates: MovieUpcomingResponse.Dates.mocked,
@@ -138,4 +119,20 @@ extension NSPersistentStoreCoordinator {
         }
         try! addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: storeURL, options: nil)
     }
+}
+
+func == (lhs: MovieUpcomingResponse.ResultsElement, rhs: Movie) -> Bool {
+    return
+        lhs.id == rhs.remoteId &&
+            lhs.adult! == rhs.adult!.boolValue &&
+            lhs.video! == rhs.video!.boolValue &&
+            lhs.backdropPath! == rhs.backdropPath! &&
+            lhs.title! == rhs.title! &&
+            lhs.posterPath! == rhs.posterPath! &&
+            lhs.overview! == rhs.overview! &&
+            lhs.originalTitle! == rhs.originalTitle! &&
+            lhs.popularity! == rhs.popularity! &&
+            lhs.originalLanguage! == rhs.originalLanguage! &&
+            lhs.releaseDate! == rhs.releaseDate! &&
+            lhs.genreIds == rhs.genreIds.map { $0.intValue }
 }

--- a/The Movie DB ClientTests/TestHelpers.swift
+++ b/The Movie DB ClientTests/TestHelpers.swift
@@ -21,63 +21,6 @@ extension MovieListLocalDataManager {
     }
 }
 
-final class MovieUpcomingResponseFactory {
-    static public var LaDoceVita: MovieUpcomingResponse.ResultsElement {
-        return MovieUpcomingResponse.ResultsElement(
-            voteCount: 501,
-            id: 439,
-            video: false,
-            voteAverage: 8.1,
-            title: "La dolce vita",
-            popularity: 10.0,
-            posterPath: "/aU7WLwPVCOoonAPWOPBmZ8X0c3c.jpg",
-            originalLanguage: "it",
-            originalTitle: "La dolce vita",
-            genreIds: [35, 18],
-            backdropPath: "/b3ofp0vhkbKsrz2V44DimBRKkxf.jpg",
-            adult: false,
-            overview: "Episodic journey of an Italian journalist scouring Rome in search of love.",
-            releaseDate: "1960-02-05"
-        )
-    }
-
-    static public var AvengersInfinityWar: MovieUpcomingResponse.ResultsElement {
-        return MovieUpcomingResponse.ResultsElement(
-            voteCount: 7745,
-            id: 299536,
-            video: false,
-            voteAverage: 8.3,
-            title: "Avengers: Infinity War",
-            popularity: 260.161,
-            posterPath: "/7WsyChQLEftFiDOVTGkv3hFpyyt.jpg",
-            originalLanguage: "it",
-            originalTitle: "La dolce vita",
-            genreIds: [35, 18],
-            backdropPath: "/bOGkgRGdhrBYJSLpXaxhXVstddV.jpg",
-            adult: false,
-            overview: """
-            As the Avengers and their allies have continued to protect the world from threats too large
-            for any one hero to handle, a new danger has emerged from the cosmic shadows: Thanos.
-            A despot of intergalactic infamy, his goal is to collect all six Infinity Stones,
-            artifacts of unimaginable power, and use them to inflict his twisted will on all of reality.
-            Everything the Avengers have fought for has led up to this moment -
-            the fate of Earth and existence itself has never been more uncertain.
-            """,
-            releaseDate: "1960-02-05"
-        )
-    }
-
-    public static var MoviesUpcoming: MovieUpcomingResponse {
-        return MovieUpcomingResponse(
-            results: [MovieUpcomingResponseFactory.AvengersInfinityWar,
-                      MovieUpcomingResponseFactory.LaDoceVita],
-            page: 1,
-            totalResults: 2,
-            dates: MovieUpcomingResponse.Dates.mocked,
-            totalPages: 1)
-    }
-}
-
 extension MovieUpcomingResponse.Dates {
     static var mocked: MovieUpcomingResponse.Dates {
         return MovieUpcomingResponse.Dates(maximum: "2018-06-10", minimum: "2018-05-15")
@@ -135,4 +78,34 @@ func == (lhs: MovieUpcomingResponse.ResultsElement, rhs: Movie) -> Bool {
             lhs.originalLanguage! == rhs.originalLanguage! &&
             lhs.releaseDate! == rhs.releaseDate! &&
             lhs.genreIds == rhs.genreIds.map { $0.intValue }
+}
+
+func == (lhs: Movie, rhs: MovieUpcomingResponse.ResultsElement) -> Bool {
+    return rhs == lhs
+}
+
+func == (lhs: TMDbApiConfiguration, rhs: TMDbApiConfigurationResponse) -> Bool {
+    return lhs.backdropSizes == rhs.images?.backdropSizes &&
+        lhs.changeKeys == rhs.changeKeys &&
+        lhs.baseUrl == rhs.images?.baseUrl &&
+        lhs.logoSizes == rhs.images?.logoSizes &&
+        lhs.stillSizes == rhs.images?.stillSizes &&
+        lhs.secureBaseUrl == rhs.images?.secureBaseUrl &&
+        lhs.profileSizes == rhs.images?.profileSizes &&
+        lhs.posterSizes == rhs.images?.posterSizes
+}
+
+func == (lhs: TMDbApiConfigurationResponse, rhs: TMDbApiConfiguration) -> Bool {
+    return rhs == lhs
+}
+
+func == (lhs: ConfigurationEntity, rhs: TMDbApiConfigurationResponse) -> Bool {
+    return lhs.backdropSizes == rhs.images?.backdropSizes &&
+        lhs.changeKeys == rhs.changeKeys &&
+        lhs.baseUrl == rhs.images?.baseUrl &&
+        lhs.logoSizes == rhs.images?.logoSizes &&
+        lhs.stillSizes == rhs.images?.stillSizes &&
+        lhs.secureBaseUrl == rhs.images?.secureBaseUrl &&
+        lhs.profileSizes == rhs.images?.profileSizes &&
+        lhs.posterSizes == rhs.images?.posterSizes
 }

--- a/The Movie DB ClientTests/TestHelpers.swift
+++ b/The Movie DB ClientTests/TestHelpers.swift
@@ -61,6 +61,22 @@ extension MovieUpcomingResponse.ResultsElement {
     }
 }
 
+func == (lhs: MovieUpcomingResponse.ResultsElement, rhs: Movie) -> Bool {
+    return
+        lhs.id == rhs.remoteId &&
+            lhs.adult! == rhs.adult!.boolValue &&
+            lhs.video! == rhs.video!.boolValue &&
+            lhs.backdropPath! == rhs.backdropPath! &&
+            lhs.title! == rhs.title! &&
+            lhs.posterPath! == rhs.posterPath! &&
+            lhs.overview! == rhs.overview! &&
+            lhs.originalTitle! == rhs.originalTitle! &&
+            lhs.popularity! == rhs.popularity! &&
+            lhs.originalLanguage! == rhs.originalLanguage! &&
+            lhs.releaseDate! == rhs.releaseDate! &&
+            lhs.genreIds == rhs.genreIds.map { $0.intValue }
+}
+
 extension MovieUpcomingResponse {
     static var mocked: MovieUpcomingResponse {
         return MovieUpcomingResponse(

--- a/The Movie DB ClientTests/TestHelpers.swift
+++ b/The Movie DB ClientTests/TestHelpers.swift
@@ -37,7 +37,26 @@ extension MovieUpcomingResponse.ResultsElement {
             backdropPath: "my/path/to/poster",
             adult: false,
             overview: "movie mock overview",
-            releaseDate: "10-11-2019"
+            releaseDate: "2018-04-05"
+        )
+    }
+
+    static var mocked2: MovieUpcomingResponse.ResultsElement {
+        return MovieUpcomingResponse.ResultsElement(
+            voteCount: 10,
+            id: 81,
+            video: false,
+            voteAverage: 100.0,
+            title: "The Sweet Life",
+            popularity: 999.0,
+            posterPath: "la/dolce/to/la/vita",
+            originalLanguage: "en",
+            originalTitle: "La Dolce Vita",
+            genreIds: [14, 23, 13, 41],
+            backdropPath: "my/path/to/poster",
+            adult: true,
+            overview: "movie mock overview",
+            releaseDate: "1960-02-05"
         )
     }
 }
@@ -50,6 +69,21 @@ extension MovieUpcomingResponse {
             totalResults: 1,
             dates: nil,
             totalPages: 1)
+    }
+
+    static var mockedWithTwoElements: MovieUpcomingResponse {
+        return MovieUpcomingResponse(
+            results: [MovieUpcomingResponse.ResultsElement.mocked, MovieUpcomingResponse.ResultsElement.mocked2],
+            page: 1,
+            totalResults: 2,
+            dates: MovieUpcomingResponse.Dates.mocked,
+            totalPages: 1)
+    }
+}
+
+extension MovieUpcomingResponse.Dates {
+    static var mocked: MovieUpcomingResponse.Dates {
+        return MovieUpcomingResponse.Dates(maximum: "2018-06-10", minimum: "2018-05-15")
     }
 }
 

--- a/The Movie DB ClientTests/TestHelpers.swift
+++ b/The Movie DB ClientTests/TestHelpers.swift
@@ -1,0 +1,86 @@
+//
+//  TestHelpers.swift
+//  The Movie DB ClientTests
+//
+//  Created by Amadeu Cavalcante on 10/08/2018.
+//  Copyright © 2018 Amadeu Cavalcante Filho. All rights reserved.
+//
+
+import Foundation
+import CoreData
+@testable import The_Movie_DB_Client
+
+extension MovieListLocalDataManager {
+	static var inMemoryLocalDataManager: MovieListLocalDataManager {
+		return MovieListLocalDataManager(managedObjectContext: NSManagedObjectContext.inMemoryTestContext())
+	}
+}
+
+extension MovieUpcomingResponse.ResultsElement {
+	static var mocked: MovieUpcomingResponse.ResultsElement {
+		return MovieUpcomingResponse.ResultsElement(
+				voteCount: 1,
+				id: 1,
+				video: false,
+				voteAverage: 10.0,
+				title: "My Title",
+				popularity: 10.0,
+				posterPath: "my/path/to/poster",
+				originalLanguage: "en",
+				originalTitle: "My original Title",
+				genreIds: [1, 2, 3, 4],
+				backdropPath: "my/path/to/poster",
+				adult: false,
+				overview: "movie mock overview",
+				releaseDate: "10-11-2019"
+		)
+	}
+}
+
+extension MovieUpcomingResponse {
+	static var mocked: MovieUpcomingResponse {
+		return MovieUpcomingResponse(
+			results: [MovieUpcomingResponse.ResultsElement.mocked],
+			page: 1,
+			totalResults: 1,
+			dates: nil,
+			totalPages: 1)
+	}
+}
+
+extension NSManagedObjectContext {
+	func performChangesAndWait(_ f: @escaping () -> ()) {
+		performAndWait {
+			f()
+			try! self.save()
+		}
+	}
+
+	static func inMemoryTestContext() -> NSManagedObjectContext {
+		return testContext { $0.addInMemoryTestStore() }
+	}
+
+	static func testContext(_ addStore: (NSPersistentStoreCoordinator) -> ()) -> NSManagedObjectContext {
+		let model = CoreDataStore.managedObjectModel
+		let coordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
+		addStore(coordinator)
+		let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+		context.persistentStoreCoordinator = coordinator
+		return context
+	}
+}
+
+extension NSPersistentStoreCoordinator {
+	func addInMemoryTestStore() {
+		try! addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
+	}
+
+	func addSQLiteTestStore() {
+		let storeURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+			.appendingPathComponent("the-client-db-test")
+		if FileManager.default.fileExists(atPath: storeURL.path) {
+			try! destroyPersistentStore(at: storeURL, ofType: NSSQLiteStoreType, options: nil)
+		}
+		try! addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: storeURL, options: nil)
+	}
+}

--- a/The Movie DB ClientTests/TestHelpers.swift
+++ b/The Movie DB ClientTests/TestHelpers.swift
@@ -11,76 +11,81 @@ import CoreData
 @testable import The_Movie_DB_Client
 
 extension MovieListLocalDataManager {
-	static var inMemoryLocalDataManager: MovieListLocalDataManager {
-		return MovieListLocalDataManager(managedObjectContext: NSManagedObjectContext.inMemoryTestContext())
-	}
+    static var
+    testResources: (localDataManager: MovieListLocalDataManager, managedObjectContext: NSManagedObjectContext) {
+        let managedObjectContext = NSManagedObjectContext.inMemoryTestContext()
+        return (
+            MovieListLocalDataManager(managedObjectContext: managedObjectContext),
+            managedObjectContext
+        )
+    }
 }
 
 extension MovieUpcomingResponse.ResultsElement {
-	static var mocked: MovieUpcomingResponse.ResultsElement {
-		return MovieUpcomingResponse.ResultsElement(
-				voteCount: 1,
-				id: 1,
-				video: false,
-				voteAverage: 10.0,
-				title: "My Title",
-				popularity: 10.0,
-				posterPath: "my/path/to/poster",
-				originalLanguage: "en",
-				originalTitle: "My original Title",
-				genreIds: [1, 2, 3, 4],
-				backdropPath: "my/path/to/poster",
-				adult: false,
-				overview: "movie mock overview",
-				releaseDate: "10-11-2019"
-		)
-	}
+    static var mocked: MovieUpcomingResponse.ResultsElement {
+        return MovieUpcomingResponse.ResultsElement(
+            voteCount: 1,
+            id: 1,
+            video: false,
+            voteAverage: 10.0,
+            title: "My Title",
+            popularity: 10.0,
+            posterPath: "my/path/to/poster",
+            originalLanguage: "en",
+            originalTitle: "My original Title",
+            genreIds: [1, 2, 3, 4],
+            backdropPath: "my/path/to/poster",
+            adult: false,
+            overview: "movie mock overview",
+            releaseDate: "10-11-2019"
+        )
+    }
 }
 
 extension MovieUpcomingResponse {
-	static var mocked: MovieUpcomingResponse {
-		return MovieUpcomingResponse(
-			results: [MovieUpcomingResponse.ResultsElement.mocked],
-			page: 1,
-			totalResults: 1,
-			dates: nil,
-			totalPages: 1)
-	}
+    static var mocked: MovieUpcomingResponse {
+        return MovieUpcomingResponse(
+            results: [MovieUpcomingResponse.ResultsElement.mocked],
+            page: 1,
+            totalResults: 1,
+            dates: nil,
+            totalPages: 1)
+    }
 }
 
 extension NSManagedObjectContext {
-	func performChangesAndWait(_ f: @escaping () -> ()) {
-		performAndWait {
-			f()
-			try! self.save()
-		}
-	}
+    func performChangesAndWait(_ f: @escaping () -> Void) {
+        performAndWait {
+            f()
+            try! self.save()
+        }
+    }
 
-	static func inMemoryTestContext() -> NSManagedObjectContext {
-		return testContext { $0.addInMemoryTestStore() }
-	}
+    static func inMemoryTestContext() -> NSManagedObjectContext {
+        return testContext { $0.addInMemoryTestStore() }
+    }
 
-	static func testContext(_ addStore: (NSPersistentStoreCoordinator) -> ()) -> NSManagedObjectContext {
-		let model = CoreDataStore.managedObjectModel
-		let coordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
-		addStore(coordinator)
-		let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
-		context.persistentStoreCoordinator = coordinator
-		return context
-	}
+    static func testContext(_ addStore: (NSPersistentStoreCoordinator) -> Void) -> NSManagedObjectContext {
+        let model = CoreDataStore.managedObjectModel
+        let coordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
+        addStore(coordinator)
+        let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+        context.persistentStoreCoordinator = coordinator
+        return context
+    }
 }
 
 extension NSPersistentStoreCoordinator {
-	func addInMemoryTestStore() {
-		try! addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
-	}
+    func addInMemoryTestStore() {
+        try! addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
+    }
 
-	func addSQLiteTestStore() {
-		let storeURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-			.appendingPathComponent("the-client-db-test")
-		if FileManager.default.fileExists(atPath: storeURL.path) {
-			try! destroyPersistentStore(at: storeURL, ofType: NSSQLiteStoreType, options: nil)
-		}
-		try! addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: storeURL, options: nil)
-	}
+    func addSQLiteTestStore() {
+        let storeURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("the-client-db-test")
+        if FileManager.default.fileExists(atPath: storeURL.path) {
+            try! destroyPersistentStore(at: storeURL, ofType: NSSQLiteStoreType, options: nil)
+        }
+        try! addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: storeURL, options: nil)
+    }
 }


### PR DESCRIPTION
Depends on #13 

@ronanrodrigo Eu precisava injetar o `managedObjectContext` dentro do `MovieListLocalDataManager`, pois daí posso colocar o `managedObjectContext` de teste, ou seja, posso colocar alguma coisa como rodar em memoria, etc...